### PR TITLE
Discontinue solidrun/hummingboard

### DIFF
--- a/solidrun-imx6.coffee
+++ b/solidrun-imx6.coffee
@@ -7,7 +7,7 @@ module.exports =
 	aliases: [ 'solidrun-imx6', 'cubox-i', 'hummingboard', 'hummingboard2' ]
 	name: 'Hummingboard'
 	arch: 'armv7hf'
-	state: 'released'
+	state: 'discontinued'
 
 	instructions: commonImg.instructions
 	gettingStartedLink:


### PR DESCRIPTION
- Discontinue Solidrun/Hummingboard. Other IMX6 boards are already discontinued in this layer.

- Update meta-balena to v2.40.0 for the only board currently in use in this repo: Nitrogen8MM