### PR TITLE
nitrogen8mm: Update flashing instructions

### DIFF
--- a/nitrogen8mm.coffee
+++ b/nitrogen8mm.coffee
@@ -2,9 +2,10 @@ deviceTypesCommon = require '@resin.io/device-types/common'
 { networkOptions, commonImg, instructions } = deviceTypesCommon
 
 BOARD_POWEROFF = 'Remove and re-connect power to the board.'
+BOARD_SHUTDOWN =  'Monitor the device in Balena dashboard to see when it entered the post-provisioning state. Leave the state settle for around 10 seconds.'
 
 postProvisioningInstructions = [
-	instructions.BOARD_SHUTDOWN
+	BOARD_SHUTDOWN
 	instructions.REMOVE_INSTALL_MEDIA
 	instructions.BOARD_REPOWER
 ]


### PR DESCRIPTION
The power LED, which is the only one on the board,
does not go off after flashing is completed. Therefore
we need to check the dashboard to see when provisioning
is finished.

Changelog-entry: nitrogen8mm: Update flashing instructions
Signed-off-by: Alexandru Costache <alexandru@balena.io>