### PR TITLE
packagegroup-resin-connectivity: Do not use wireless-regdb-static

### DIFF
--- a/layers/meta-balena-fsl-arm/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
+++ b/layers/meta-balena-fsl-arm/recipes-core/packagegroups/packagegroup-resin-connectivity.bbappend
@@ -1,2 +1,5 @@
 # Hummingboard platforms have BCM4330 optional WiFi modules
 CONNECTIVITY_FIRMWARES_append_solidrun-imx6 = " bcm4330-nvram-config bcm4329-nvram-config linux-firmware-wl18xx ti-bt-firmware"
+
+# the machines in this repo are still on kernel < 4.15 so let's not use wireless-regdb-static just yet
+CONNECTIVITY_FIRMWARES_remove = "wireless-regdb-static"


### PR DESCRIPTION
The machines in this repo are still on kernel < 4.15 so let's not use
wireless-regdb-static just yet. When they will use a kernel >= 4.15
let's switch then from crda to wireless-regdb-static.

Changelog-entry: Do not use wireless-regdb-static until we move to kernel >= 4.15
Signed-off-by: Florin Sarbu <florin@balena.io>