### PR TITLE
linux-boundary: Update to include fix for kworker high CPU

### DIFF
--- a/layers/meta-balena-fsl-arm/recipes-kernel/linux/linux-boundary_%.bbappend
+++ b/layers/meta-balena-fsl-arm/recipes-kernel/linux/linux-boundary_%.bbappend
@@ -3,7 +3,7 @@ inherit kernel-resin
 # Use latest and known to boot version,
 # and the one that includes patch for
 # setting zwave reset as active high
-SRCREV = "8e671435b2c00c2c682ba2895821d6e76fad7951"
+SRCREV = "47a070fb51bfafbce4dc6089be3a19d027d16b55"
 
 # Disable commit SHA in kernel version string
 SCMVERSION="n"


### PR DESCRIPTION
It was reported that kworker may use more CPU
than expected. Let's update to latest Boundary
kernel HEAD revision to include the fix.

Changelog-entry: linux-boundary: Update to include fix for kworker high CPU
Signed-off-by: Alexandru Costache <alexandru@balena.io>