### PR TITLE
nitrogen8mm-dwe: Fix USB warning in dashboard

### DIFF
--- a/nitrogen8mm-dwe.coffee
+++ b/nitrogen8mm-dwe.coffee
@@ -14,19 +14,19 @@ postProvisioningInstructions = [
 	WRITE_BALENA_UBOOT
 ]
 
-imageDownloadAlerts: [
-	{
-		type: 'warning'
-		message: 'To run the hostOS from a USB stick, please first ensure latest imx-boot has been written to /dev/mmcblk0boot0, and the emmc - /dev/mmcblk0 - does not contain any balena image or balena partitions.'
-	}
-]
-
 module.exports =
 	version: 1
 	slug: 'nitrogen8mm-dwe'
 	name: 'Nitrogen8MM DWE'
 	arch: 'aarch64'
 	state: 'new'
+
+	imageDownloadAlerts: [
+		{
+		type: 'warning'
+		message: 'To run the hostOS from a USB stick, please first ensure latest imx-boot has been written to /dev/mmcblk0boot0, and the emmc - /dev/mmcblk0 - does not contain any balena image or balena partitions.'
+		}
+	]
 
 	stateInstructions:
 		postProvisioning: postProvisioningInstructions


### PR DESCRIPTION
USB warning does not appear in dashboard, looks like it
has to do with location of variable definition.

Changelog-entry: nitrogen8mm-dwe: Fix USB warning in dashboard
Signed-off-by: Alexandru Costache <alexandru@balena.io>