### PR TITLE
linux-boundary: Disable CQE for SBC eMMC

### DIFF
--- a/layers/meta-balena-fsl-arm/recipes-kernel/linux/linux-boundary/imx8mm-sbc-add-no-cqe-for-eMMC.patch
+++ b/layers/meta-balena-fsl-arm/recipes-kernel/linux/linux-boundary/imx8mm-sbc-add-no-cqe-for-eMMC.patch
@@ -1,0 +1,29 @@
+From be02ed6bb6974b40e1a0fe87540adc68607ca90e Mon Sep 17 00:00:00 2001
+From: Alexandru Costache <alexandru@balena.io>
+Date: Wed, 30 Sep 2020 17:42:18 +0200
+Subject: [PATCH] arm64: dts: imx8mm-sbc: add no-cqe for eMMC
+
+BD recommends having CQE disabled for the SBC too
+to avoid freezes in case of cqe errors.
+
+Upstream-status: Inappropriate [configuration]
+Signed-off-by: Alexandru Costache <alexandru@balena.io>
+---
+ arch/arm64/boot/dts/freescale/imx8mmn-nitrogen8mm.dtsi | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/arm64/boot/dts/freescale/imx8mmn-nitrogen8mm.dtsi b/arch/arm64/boot/dts/freescale/imx8mmn-nitrogen8mm.dtsi
+index 88cb9fa..e269bbd 100644
+--- a/arch/arm64/boot/dts/freescale/imx8mmn-nitrogen8mm.dtsi
++++ b/arch/arm64/boot/dts/freescale/imx8mmn-nitrogen8mm.dtsi
+@@ -1173,6 +1173,7 @@
+ 	bus-width = <8>;
+ 	no-mmc-hs400;
+ 	non-removable;
++	no-cqe;
+ 	pinctrl-names = "default", "state_100mhz", "state_200mhz";
+ 	pinctrl-0 = <&pinctrl_usdhc1>;
+ 	pinctrl-1 = <&pinctrl_usdhc1_100mhz>;
+-- 
+2.7.4
+

--- a/layers/meta-balena-fsl-arm/recipes-kernel/linux/linux-boundary_%.bbappend
+++ b/layers/meta-balena-fsl-arm/recipes-kernel/linux/linux-boundary_%.bbappend
@@ -1,3 +1,5 @@
+FILESEXTRAPATHS_append := ":${THISDIR}/${PN}"
+
 inherit kernel-resin
 
 # Use latest and known to boot version,
@@ -7,3 +9,7 @@ SRCREV = "519c68394326d9d3d00776dc71eb62f70bed74bc"
 
 # Disable commit SHA in kernel version string
 SCMVERSION="n"
+
+SRC_URI_append = " \
+	file://imx8mm-sbc-add-no-cqe-for-eMMC.patch \
+"


### PR DESCRIPTION
BD recommends disabling CQE for the SBC, just
like HUB3 does, to avoid possible freezes in
case of cqe errors.

linux-boundary: Disable CQE for SBC eMMC
Signed-off-by: Alexandru Costache <alexandru@balena.io>