### PR TITLE
u-boot: Bring in eth PHY reset fix

### DIFF
--- a/layers/meta-balena-fsl-arm/recipes-bsp/u-boot/u-boot-boundary_%.bbappend
+++ b/layers/meta-balena-fsl-arm/recipes-bsp/u-boot/u-boot-boundary_%.bbappend
@@ -5,7 +5,7 @@ inherit resin-u-boot
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 # Override bsp layer autorev and use latest revision
-SRCREV="cc96aa68fb9ee1dc1381c71704681a34828f18ad"
+SRCREV="616d48151df1499f43bb5a5d90676df1a316b5da"
 
 # resin-u-boot class patch is rebased
 SRC_URI_remove = " file://resin-specific-env-integration-kconfig.patch"


### PR DESCRIPTION
This revision includes a recommended fix from Boundary for eth PHY reset
issues on the nitrogen8mm-dwe board.

Changelog-entry: u-boot: Bring in fix for eth PHY reset issue
Signed-off-by: Florin Sarbu <florin@balena.io>