### PR TITLE
nitrogen8mm-dwe.coffee: Switch board back to public

### DIFF
--- a/nitrogen8mm-dwe.coffee
+++ b/nitrogen8mm-dwe.coffee
@@ -20,7 +20,7 @@ module.exports =
 	name: 'Nitrogen8MM HUB3'
 	arch: 'aarch64'
 	state: 'new'
-	private: true
+	private: false
 
 	imageDownloadAlerts: [
 		{


### PR DESCRIPTION
We do not have yet all the bits and pieces in our infrastructure to
handle this transition at this time so let's make the board public
again.

Changelog-entry: Switch nitrogen8mm-dwe back to public
Signed-off-by: Florin Sarbu <florin@balena.io>