### PR TITLE
balena-image-initramfs: remove the migrate and recovery modules

### DIFF
--- a/layers/meta-balena-fsl-arm/recipes-core/images/balena-image-initramfs.bbappend
+++ b/layers/meta-balena-fsl-arm/recipes-core/images/balena-image-initramfs.bbappend
@@ -1,3 +1,5 @@
 PACKAGE_INSTALL:solidrun-n6g += " \
     firmware-imx-sdma-imx6q \
 "
+
+PACKAGE_INSTALL:remove:nitrogen8mm-dwe = " initramfs-module-recovery initramfs-module-migrate"


### PR DESCRIPTION
These new meta-balena functionality grows the initramfs image and it no longer fits in the allocated root filesystem partition.

Removing the recovery and migrate modules from this device type only means that the new functionality won't be available for this device type.

Changelog-entry: remove migrate and recovery initramfs modules from nitrogen8mm-dwe