### PR TITLE
Optimize build for size

### DIFF
--- a/layers/meta-balena-fsl-arm/conf/layer.conf
+++ b/layers/meta-balena-fsl-arm/conf/layer.conf
@@ -22,6 +22,7 @@ BBMASK += "meta-boundary/recipes-boundary/images"
 BBMASK += "meta-solidrun-arm-imx6/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.12.%.bbappend"
 BBMASK += "meta-boundary/recipes-graphics/wayland/weston_4.0.0.imx.bbappend"
 BBMASK += "meta-boundary/recipes-qt/"
+BBMASK += "meta-boundary/classes/image_types_boundary.bbclass"
 
 ACCEPT_FSL_EULA = "1"
 

--- a/layers/meta-balena-fsl-arm/conf/layer.conf
+++ b/layers/meta-balena-fsl-arm/conf/layer.conf
@@ -33,7 +33,7 @@ KERNEL_DEVICETREE:append:nitrogen8mm = " \
         freescale/imx8mm-nitrogen8mm_rev2-m4.dtb \
 "
 
-FIRMWARE_COMPRESSION_nitrogen8mm ?= "1"
+FIRMWARE_COMPRESSION:nitrogen8mm ?= "1"
 
 # Temporarily removed until the solidrun upstream repo adds honister support: https://github.com/SolidRun/meta-solidrun-solidsense/issues/2
 BBMASK += "meta-balena-fsl-arm/recipes-bsp/u-boot/u-boot-solidsense-imx6_%.bbappend"

--- a/layers/meta-balena-fsl-arm/recipes-core/images/balena-image-initramfs.bbappend
+++ b/layers/meta-balena-fsl-arm/recipes-core/images/balena-image-initramfs.bbappend
@@ -2,4 +2,5 @@ PACKAGE_INSTALL:solidrun-n6g += " \
     firmware-imx-sdma-imx6q \
 "
 
-PACKAGE_INSTALL:remove:nitrogen8mm-dwe = " initramfs-module-recovery initramfs-module-migrate"
+PACKAGE_INSTALL:remove:nitrogen8mm = " initramfs-module-recovery initramfs-module-migrate"
+PACKAGE_INSTALL:remove = "mdraid"

--- a/layers/meta-balena-fsl-arm/recipes-core/images/balena-image.inc
+++ b/layers/meta-balena-fsl-arm/recipes-core/images/balena-image.inc
@@ -136,5 +136,5 @@ IMAGE_INSTALL:append:emgw3 = " \
 
 DEPENDS:append:nitrogen8mm += "imx-boot"
 
-# the BSP sets this variable in the machine conf so let's unset it since this makes our build fail
+# the BSP sets this variable so let's unset it since this makes our build fail
 unset ROOTFS_SIZE

--- a/layers/meta-balena-fsl-arm/recipes-core/images/balena-image.inc
+++ b/layers/meta-balena-fsl-arm/recipes-core/images/balena-image.inc
@@ -135,3 +135,6 @@ IMAGE_INSTALL:append:emgw3 = " \
 "
 
 DEPENDS:append:nitrogen8mm += "imx-boot"
+
+# the BSP sets this variable in the machine conf so let's unset it since this makes our build fail
+unset ROOTFS_SIZE

--- a/layers/meta-balena-fsl-arm/recipes-kernel/linux/linux-boundary_%.bbappend
+++ b/layers/meta-balena-fsl-arm/recipes-kernel/linux/linux-boundary_%.bbappend
@@ -11,3 +11,8 @@ SCMVERSION="n"
 SRC_URI:append = " \
 	file://imx8mm-sbc-add-no-cqe-for-eMMC.patch \
 "
+
+BALENA_CONFIGS:append = " optimize-size"
+BALENA_CONFIGS[optimize-size] = " \
+    CONFIG_CC_OPTIMIZE_FOR_SIZE=y \
+"


### PR DESCRIPTION
As of right now the kernel no longer fits in the rootfs, we need to make some more space and make sure ROOTFS_SIZE is not set by the BSP