### PR TITLE
linux-boundary: Ensure apparmor is disabled

### DIFF
--- a/layers/meta-balena-fsl-arm/recipes-kernel/linux/linux-boundary_%.bbappend
+++ b/layers/meta-balena-fsl-arm/recipes-kernel/linux/linux-boundary_%.bbappend
@@ -12,7 +12,12 @@ SRC_URI:append = " \
 	file://imx8mm-sbc-add-no-cqe-for-eMMC.patch \
 "
 
-BALENA_CONFIGS:append = " optimize-size"
+BALENA_CONFIGS:append = " optimize-size disable_apparmor"
 BALENA_CONFIGS[optimize-size] = " \
     CONFIG_CC_OPTIMIZE_FOR_SIZE=y \
 "
+
+BALENA_CONFIGS[disable_apparmor] = " \
+    CONFIG_SECURITY_APPARMOR=n \
+"
+


### PR DESCRIPTION
Currently balenaOS disables DEFAULT_SECURITY_APPARMOR due to containers failing to start with missing dependencies.

The BSP enables CONFIG_SECURITY_APPARMOR and the final result is apparmor enabled although disabled from meta-balena.

Changelog-entry: ensure apparmor is disabled