### PR TITLE
Update balena-image-initramfs.bbappend

### DIFF
--- a/layers/meta-balena-fsl-arm/recipes-core/images/balena-image-initramfs.bbappend
+++ b/layers/meta-balena-fsl-arm/recipes-core/images/balena-image-initramfs.bbappend
@@ -2,5 +2,5 @@ PACKAGE_INSTALL:solidrun-n6g += " \
     firmware-imx-sdma-imx6q \
 "
 
-PACKAGE_INSTALL:remove:nitrogen8mm = " initramfs-module-recovery initramfs-module-migrate"
+PACKAGE_INSTALL:remove:nitrogen8mm = " initramfs-module-recovery"
 PACKAGE_INSTALL:remove = "mdraid"


### PR DESCRIPTION
On other devices we observed that without the migrate module inactive sysroot automount will hang on first boot after provisioning. Upon reboot the problem is no longer present.