### PR TITLE
Revert "layers/meta-balena-fsl-arm/conf/layer.conf: Compress kernel f…

### DIFF
--- a/layers/meta-balena-fsl-arm/conf/layer.conf
+++ b/layers/meta-balena-fsl-arm/conf/layer.conf
@@ -46,6 +46,3 @@ FULL_OPTIMIZATION = "-Os -pipe ${DEBUG_FLAGS}"
 
 # Temporarily removed until the solidrun upstream repo adds honister support: https://github.com/SolidRun/meta-solidrun-solidsense/issues/2
 BBMASK += "meta-balena-fsl-arm/recipes-bsp/u-boot/u-boot-solidsense-imx6_%.bbappend"
-
-# this board is very low on rootfs space so we need to compress the kernel in order to save space
-KERNEL_IMAGETYPE:nitrogen8mm = "Image.gz"


### PR DESCRIPTION
…or nitrogen8mm"

This reverts commit b8cc3390f3bd3c763d5b70f96a663b5cfdf39898.

We now have enabled kernel module compression in meta-balena which saves us enough space so we can revert the kernel image compression. The kernel image compression commit also needed additional changes in u-boot which were not made so for now it is faster to fix it by reverting the kernel compression.

Changelog-entry: Revert kernel compression for nitrogen8mm based boards