### PR TITLE
nitrogen8mm-dwe.coffee: Specify the deploy flasher artifact

### DIFF
--- a/nitrogen8mm-dwe.coffee
+++ b/nitrogen8mm-dwe.coffee
@@ -44,10 +44,11 @@ module.exports =
 
 	yocto:
 		machine: 'nitrogen8mm-dwe'
-		image: 'balena-image'
+		image: 'balena-image-flasher'
 		fstype: 'balenaos-img'
 		version: 'yocto-kirkstone'
 		deployArtifact: 'balena-image-nitrogen8mm-dwe.balenaos-img'
+		deployFlasherArtifact: 'balena-image-flasher-nitrogen8mm-dwe.balenaos-img'
 		compressed: true
 
 	options: [ networkOptions.group ]


### PR DESCRIPTION
For automated testing we need to use the flasher image to provision the board. The customer will keep using the internal image for provisioning, which is the image that will continue to be offered in the dashboard.

Changelog-entry: Specify in the coffee file what is the deployFlasherArtifact for nitrogen8mm-dwe.coffee