### PR TITLE
Allow overriding default test image

### DIFF
--- a/.github/workflows/nitrogen8mm-dwe.yml
+++ b/.github/workflows/nitrogen8mm-dwe.yml
@@ -61,3 +61,13 @@ jobs:
       deploy-environment: ${{ inputs.deploy-environment || 'balena-cloud.com' }}
       # Allow overriding the meta-balena ref for workflow dispatch events
       meta-balena-ref: ${{ inputs.meta-balena-ref || '' }}
+      # Disable finalize-on-push until we have automated HUP tests for DT's needing the non-default image
+      finalize-on-push-if-tests-passed: false
+      # Disable HUP suite for now - as it won't work without leviathan changes
+      test_matrix: >
+        {
+          "test_suite": ["os","cloud"],
+          "environment": ["balena-cloud.com"],
+          "runs_on": [["self-hosted"]],
+          "test_image": ["balena-flasher.img"],
+        }


### PR DESCRIPTION
This enables using the flasher image in testing, while still deploying the non flasher

Changelog-entry: Allow overriding default test image


requires: https://github.com/balena-os/balena-yocto-scripts/pull/555 - pinned action to that branch for debugging - ensure that this is put back before merge

HUP suite disabled due to needing modifications to leviathan to support it, including: https://github.com/balena-os/leviathan/issues/1286