### PR TITLE
bluetooth-scripts: Fix bluetooth on new kernel for nitrogen8mm

### DIFF
--- a/layers/meta-balena-fsl-arm/recipes-connectivity/bluetooth-scripts/files/nitrogen8mm-hci.service
+++ b/layers/meta-balena-fsl-arm/recipes-connectivity/bluetooth-scripts/files/nitrogen8mm-hci.service
@@ -10,4 +10,4 @@ Type=oneshot
 
 # Use this service file approach to bring up hci0 for now
 # since an udev rule for this does not work at startup, only at runtime
-ExecStart=/bin/bash -c 'while [ ! -d /sys/devices/platform/soc@0/soc@0:bus@30800000/30860000.serial/tty/ttymxc0/device ]; do sleep 1; done; rfkill unblock bluetooth; /usr/bin/hciconfig hci0 up'
+ExecStart=/bin/bash -c 'while [ ! -d /sys/devices/platform/soc\@0/30800000.bus/30800000.spba-bus/30860000.serial/tty/ttymxc0/device ]; do sleep 1; done; rfkill unblock bluetooth; /usr/bin/hciconfig hci0 up'


### PR DESCRIPTION
The path for testing when the UART device has been attached to the Bluez stack changed again in the new kernel.

Changelog-entry: Fix bluetooth on new kernel for nitrogen8mm