### PR TITLE
Fix usrmerge builds

### DIFF
--- a/layers/meta-balena-fsl-arm/recipes-connectivity/bluetooth-scripts/bluetooth-scripts.bb
+++ b/layers/meta-balena-fsl-arm/recipes-connectivity/bluetooth-scripts/bluetooth-scripts.bb
@@ -12,9 +12,9 @@ SRC_URI += " \
 "
 
 FILES:${PN} = " \
-    /lib/systemd/nitrogen8mm-bluetooth.sh \
-    /lib/systemd/system/nitrogen8mm-bluetooth.service \
-    /lib/systemd/system/nitrogen8mm-hci.service \
+    ${nonarch_base_libdir}/systemd/nitrogen8mm-bluetooth.sh \
+    ${nonarch_base_libdir}/systemd/system/nitrogen8mm-bluetooth.service \
+    ${nonarch_base_libdir}/systemd/system/nitrogen8mm-hci.service \
 "
 
 SYSTEMD_SERVICE:${PN} = "nitrogen8mm-bluetooth.service nitrogen8mm-hci.service"

--- a/layers/meta-balena-fsl-arm/recipes-kernel/linux-firmware/linux-firmware-bdsdmac_git.bbappend
+++ b/layers/meta-balena-fsl-arm/recipes-kernel/linux-firmware/linux-firmware-bdsdmac_git.bbappend
@@ -1,0 +1,7 @@
+do_install() {
+        sed -i 's|/lib/firmware|""|g' Makefile
+        DESTDIR=${D}${nonarch_base_libdir}/firmware make install
+}
+
+
+FILES:${PN} = "${nonarch_base_libdir}/firmware/* ${nonarch_base_libdir}/firmware/*/*"

--- a/layers/meta-balena-fsl-arm/recipes-kernel/linux-firmware/linux-firmware-cypress_git.bbappend
+++ b/layers/meta-balena-fsl-arm/recipes-kernel/linux-firmware/linux-firmware-cypress_git.bbappend
@@ -1,0 +1,6 @@
+do_install() {
+        sed -i 's|/lib/firmware|""|g' Makefile
+        DESTDIR=${D}${nonarch_base_libdir}/firmware make install
+}
+
+FILES:${PN} += "${nonarch_base_libdir}/firmware/* ${nonarch_base_libdir}/firmware/*/*"

--- a/layers/meta-balena-fsl-arm/recipes-kernel/linux-firmware/linux-firmware-gslx680_1.0.bbappend
+++ b/layers/meta-balena-fsl-arm/recipes-kernel/linux-firmware/linux-firmware-gslx680_1.0.bbappend
@@ -1,0 +1,6 @@
+do_install() {
+    mkdir -p ${D}/${nonarch_base_libdir}/firmware/silead
+    install -m 0644 ${WORKDIR}/gsl1680.fw ${D}/${nonarch_base_libdir}/firmware/silead/
+}
+
+FILES_${PN} += "${nonarch_base_libdir}/firmware/*"

--- a/layers/meta-balena-fsl-arm/recipes-kernel/linux-firmware/linux-firmware-sx-pceac2_git.bbappend
+++ b/layers/meta-balena-fsl-arm/recipes-kernel/linux-firmware/linux-firmware-sx-pceac2_git.bbappend
@@ -1,0 +1,6 @@
+do_install() {
+	install -d ${D}${nonarch_base_libdir}/firmware
+	cp -r ${S}/* ${D}${nonarch_base_libdir}/firmware/
+}
+
+FILES_${PN} += "/${nonarch_base_libdir}/firmware/* /${nonarch_base_libdir}/firmware/*/*"

--- a/layers/meta-balena-fsl-arm/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/layers/meta-balena-fsl-arm/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -1,3 +1,9 @@
+SRC_URI:remove = "https://git.ti.com/ti-bt/service-packs/blobs/raw/54f5c151dacc608b19ab2ce4c30e27a3983048b2/initscripts/TIInit_7.6.15.bts;name=TIInit_7.6.15"
+
+SRC_URI:append = " \
+    https://git.ti.com/cgit/ti-bt/service-packs/plain/initscripts/TIInit_7.6.15.bts?id=54f5c151dacc608b19ab2ce4c30e27a3983048b2;name=TIInit_7.6.15;downloadfilename=TIInit_7.6.15.bts \
+"
+
 do_install:prepend(){
     install -d  ${D}/lib/firmware/ti-connectivity/
 }

--- a/layers/meta-balena-fsl-arm/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/layers/meta-balena-fsl-arm/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -1,0 +1,12 @@
+do_install:prepend(){
+    install -d  ${D}/lib/firmware/ti-connectivity/
+}
+
+
+do_install:append() {
+    rm -rf ${D}/lib/
+    install -d ${D}/${nonarch_base_libdir}/firmware/ti-connectivity/
+    cp ${WORKDIR}/TIInit_7.6.15.bts ${D}/${nonarch_base_libdir}/firmware/ti-connectivity/
+}
+
+


### PR DESCRIPTION
This PR fixes the errors encountered when building with balenaOS v6.5.30, which enables usrmerge