### PR TITLE
emgw3.coffee: Specify the flasher artifact

### DIFF
--- a/emgw3.coffee
+++ b/emgw3.coffee
@@ -36,10 +36,11 @@ module.exports =
 
 	yocto:
 		machine: 'emgw3'
-		image: 'balena-image'
+		image: 'balena-image-flasher'
 		fstype: 'balenaos-img'
 		version: 'yocto-kirkstone'
 		deployArtifact: 'balena-image-emgw3.balenaos-img'
+		deployFlasherArtifact: 'balena-image-flasher-emgw3.balenaos-img'
 		compressed: true
 
 	options: [ networkOptions.group ]


### PR DESCRIPTION
For automated testing we need to use the flasher image to provision the board. The customer will keep using the internal image for provisioning, which is the image that will continue to be offered in the dashboard.

Changelog-entry: Specify in the coffee file what is the flasher image for emgw3