### PR TITLE
linux-firmware: update ref to ti-bt

### DIFF
--- a/layers/meta-balena-fsl-arm/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/layers/meta-balena-fsl-arm/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -1,7 +1,7 @@
 SRC_URI:remove = "https://git.ti.com/ti-bt/service-packs/blobs/raw/54f5c151dacc608b19ab2ce4c30e27a3983048b2/initscripts/TIInit_7.6.15.bts;name=TIInit_7.6.15"
 
 SRC_URI:append = " \
-    https://git.ti.com/cgit/ti-bt/service-packs/plain/initscripts/TIInit_7.6.15.bts?id=54f5c151dacc608b19ab2ce4c30e27a3983048b2;name=TIInit_7.6.15;downloadfilename=TIInit_7.6.15.bts \
+    https://git.ti.com/cgit/ti-bt/service-packs/plain/initscripts/TIInit_7.6.15.bts?id=54f5c151dacc608b19ab2ce4c30e27a3983048b2 \
 "
 
 do_install:prepend(){


### PR DESCRIPTION
When manually trying to donwload the blob, I have to remove change the url by removing the name and downloadfilename - trying to fix builds by doing the same here

Changelog-entry: linux-firmware: update ref to ti-bt