### PR TITLE
Add new systemd bt init service for emgw3 machines with a different b…

### DIFF
--- a/layers/meta-balena-fsl-arm/recipes-connectivity/gecko-uart/gecko-uart.bb
+++ b/layers/meta-balena-fsl-arm/recipes-connectivity/gecko-uart/gecko-uart.bb
@@ -1,0 +1,25 @@
+SUMMARY = "gecko uart attach service"
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+LICENSE = "MIT"
+
+SRC_URI = "file://sl-uart.service \
+	   file://sl-uart.sh \
+"
+
+inherit systemd
+
+do_install:append() {
+
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
+        install -d ${D}${systemd_unitdir}/system
+        install -m 644 ${WORKDIR}/sl-uart.service ${D}${systemd_unitdir}/system
+    fi
+
+	install -d ${D}${datadir}/gecko-uart/
+	install -m 755 ${WORKDIR}/sl-uart.sh ${D}${datadir}/gecko-uart/
+}
+
+FILES:${PN} += "/usr/share/gecko-uart/*"
+
+SYSTEMD_SERVICE:${PN} = "sl-uart.service"

--- a/layers/meta-balena-fsl-arm/recipes-connectivity/gecko-uart/gecko-uart/sl-uart.service
+++ b/layers/meta-balena-fsl-arm/recipes-connectivity/gecko-uart/gecko-uart/sl-uart.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Attaching SiliconLabs UART to bluetooth
+Requires=bluetooth.target
+After=bluetooth.target silex-uart.service
+ConditionPathExists=/var/lib/bluetooth/firmware/rcp
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash /usr/share/gecko-uart/sl-uart.sh start
+ExecStop=/bin/bash  /usr/share/gecko-uart/sl-uart.sh stop
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/layers/meta-balena-fsl-arm/recipes-connectivity/gecko-uart/gecko-uart/sl-uart.sh
+++ b/layers/meta-balena-fsl-arm/recipes-connectivity/gecko-uart/gecko-uart/sl-uart.sh
@@ -1,0 +1,136 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides: bluetooth-uart
+# Required-Start:    $local_fs $syslog $remote_fs dbus
+# Required-Stop:     $local_fs $syslog $remote_fs
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Attaching UART to Bluez stack
+### END INIT INFO
+#
+
+DESC="sl-uart"
+PATH="/sbin:/bin:/usr/sbin:/usr/bin"
+HCIATTACH=$(command -v hciattach)
+HCICONFIG=$(command -v hciconfig)
+SL_ATTACH_CMD="$HCIATTACH -p /dev/ttymxc0 any 1000000 noflow"
+SL_UART_DEVICE="/sys/class/tty/ttymxc0/"
+
+# Check for required commands
+if [ -z "$HCIATTACH" ] || [ -z "$HCICONFIG" ]; then
+    echo "Error: Required commands not found. Please install bluez package."
+    exit 1
+fi
+
+test -f /etc/default/bluetooth && . /etc/default/bluetooth
+
+#. /lib/lsb/init-functions
+
+set -e
+
+start_sl()
+{
+    echo "Attaching SL Gecko module as HCI device..."
+    $SL_ATTACH_CMD > /dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        echo "Error: Failed to attach SL Gecko module as an HCI device."
+        return 1
+    fi
+    
+    # Wait briefly for the device to initialize
+    sleep 1
+    
+     # Assign HCI interface name to a variable
+    GECKO_HCI_IF=$(ls $SL_UART_DEVICE | grep 'hci')
+
+    # Check if the variable is empty
+    if [ -z "$GECKO_HCI_IF" ]; then
+        echo "Error: HCI interface couldn't be identified for SL Gecko module."
+        exit 1
+    fi
+
+    # Bring up the HCI interface
+    echo "Bringing up $GECKO_HCI_IF"
+    $HCICONFIG $GECKO_HCI_IF up
+    if [ $? -ne 0 ]; then
+        echo "Error: Failed to bring up $GECKO_HCI_IF"
+    return 1
+    fi
+    
+    return 0
+}
+
+stop_sl()
+{
+    HCIATTACH_PID=$(pgrep -f "$SL_ATTACH_CMD") 
+    if [ -n "$HCIATTACH_PID" ]; then
+        echo "Killing hciattach process for SL Gecko module"
+        kill -9 $HCIATTACH_PID
+    fi
+}
+
+check_status()
+{
+    HCIATTACH_PID=$(pgrep -f "$SL_ATTACH_CMD")
+    if [ -n "$HCIATTACH_PID" ]; then
+        echo "$DESC is running (PID: $HCIATTACH_PID)"
+        $HCICONFIG | grep -A 2 "hci"
+        return 0
+    else
+        echo "$DESC is not running"
+        return 1
+    fi
+}
+
+usage()
+{
+    echo "Usage: $0 {start|stop|restart|force-reload|status}"
+    exit 1
+}
+
+case $1 in
+    start)
+        echo "Starting $DESC"
+        if test "$BLUETOOTH_ENABLED" = 0 ; then
+            echo "bluetooth disabled. see /etc/default/bluetooth"
+            exit 0
+        fi
+  
+        # Attach Gecko module as an HCI device over UART
+        if ! start_sl; then
+            echo "Error: Failed to start SL Gecko module."
+            exit 1
+        fi
+
+        exit 0
+    ;;
+
+    stop)
+        echo "Stopping $DESC"
+        if test "$BLUETOOTH_ENABLED" = 0 ; then
+            echo "bluetooth disabled. see /etc/default/bluetooth"
+            exit 0
+        fi
+
+        stop_sl
+        exit 0
+    ;;
+
+    restart|force-reload)
+        $0 stop
+        sleep 1
+        $0 start
+        exit 0;
+    ;;
+
+    status)
+        check_status
+        exit $?
+    ;;
+
+    *)
+        usage
+    ;;
+esac
+
+exit 0

--- a/layers/meta-balena-fsl-arm/recipes-core/images/balena-image.inc
+++ b/layers/meta-balena-fsl-arm/recipes-core/images/balena-image.inc
@@ -146,6 +146,7 @@ IMAGE_INSTALL:append:nitrogen8mm = " \
 IMAGE_INSTALL:append:emgw3 = " \
 	silex-uart \
 	udev-rules-bt \
+	gecko-uart \
 "
 
 IMAGE_INSTALL:append:imx8mm-lpddr4-evk = " \


### PR DESCRIPTION
…luetooth firmware

This systemd service will only run on machines which have a certain file created in /var/lib/bluetooth/firmware/ This file can be created at fleet level by the application based on the existence of a certain env var for example.

Changelog-entry: Add systemd service for initializing bluetooth on emgw3 boards with a different bluetooth firmware